### PR TITLE
avoid depending on lustre at runtime (TOSS-2813)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,6 +13,7 @@ X_AC_EXPAND_INSTALL_DIRS
 # Automake support
 ##
 AM_INIT_AUTOMAKE([subdir-objects])
+AM_SILENT_RULES([yes])
 AM_CONFIG_HEADER([config/config.h])
 AM_MAINTAINER_MODE
 
@@ -55,6 +56,7 @@ AC_CHECK_FUNCS( \
   getopt_long \
 )
 AC_SEARCH_LIBS([clnt_create],[nsl])
+AC_SEARCH_LIBS([dlerror],[dl])
 AC_LUSTRE
 
 ##

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,8 +5,6 @@ bin_PROGRAMS = quota repquota
 quota_SOURCES = quota.c $(common_sources)
 repquota_SOURCES = repquota.c $(common_sources)
 
-LDADD = $(LIBLUSTREAPI)
-
 common_sources = \
   getquota.c getquota.h getquota_private.h getquota_nfs.c getquota_lustre.c \
   util.c util.h list.c list.h getconf.c getconf.h \

--- a/src/getquota_lustre.c
+++ b/src/getquota_lustre.c
@@ -3,20 +3,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Quota, a remote quota program.
  *  For details, see <http://www.llnl.gov/linux/quota/>.
- *  
+ *
  *  Quota is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Quota is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Quota; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -46,7 +46,7 @@
 
 extern char *prog;
 
-static qstate_t 
+static qstate_t
 set_state(unsigned long long used, unsigned long long soft,
           unsigned long long hard, unsigned long long xtim, time_t now)
 {


### PR DESCRIPTION
Avoid linking directly with `-llustreapi`.  Instead, `dlopen()` the library on demand, if available.  This should prevent `rpmbuild` picking up a dependency on the `lustre` RPM when building the binary package.
