### PR TITLE
ratchet down NFS quota timeouts

### DIFF
--- a/man/quota.1.in
+++ b/man/quota.1.in
@@ -2,28 +2,28 @@
 .SH NAME
 quota \- display file system quota information
 .SH SYNOPSIS
-.B quota 
+.B quota
 .I "[-v] [-l] [-t sec] [-r] [-f configfile] [user]"
 .br
 .SH DESCRIPTION
-.B quota 
-displays file system usage and quota limits for ``user''.  
+.B quota
+displays file system usage and quota limits for ``user''.
 .LP
 Quotas can be independently established for disk storage space
 and number of files.
 If a quota is not imposed, it will appear as ``n/a'' in \fIquota -v\fR output.
 .LP
-Hard quotas are enforced by the file system; for example, 
-a \fIwrite(2)\fR which would exceed the hard disk usage quota will 
+Hard quotas are enforced by the file system; for example,
+a \fIwrite(2)\fR which would exceed the hard disk usage quota will
 fail with ENOSPC.
 .LP
 Soft quotas are advisory for a configurable grace period, then are
-enforced as hard quotas.  
+enforced as hard quotas.
 .SH OPTIONS
 Run without arguments, \fIquota\fR only reports quota violations.
 It is intended to run in a login script to notify users when they
 need to take action.  The following arguments are available:
-.TP 
+.TP
 \fI-v\fR, \fI--verbose\fR
 Report on file systems even if quota limits are not exceeded.
 .TP
@@ -40,6 +40,15 @@ config file.
 \fI-f\fR, \fI--config\fR \fIconfigfile\fR
 loads a configuration file other than the default (see FILES below).
 A file name of \f-\fR indicates standard input.
+.TP
+\fI-N\fR, \fI--nfs-timeout\fR \fIseconds\fR
+If a response to a single UDP NFS rquota RPC, including retries,
+is not received within this timeout, the RPC is aborted with a timeout error
+(default 2.5 seconds).
+.TP
+\fI-R\fR, \fI--nfs-retry-timeout\fR \fIseconds\fR
+If a response to a single UDP NFS rquota RPC is not received within this
+timeout, the request is retransmitted (default 0.5 seconds).
 .TP
 \fIuser\fR
 View the quota of another user.

--- a/man/repquota.8.in
+++ b/man/repquota.8.in
@@ -10,10 +10,10 @@ repquota \- report file system quota information
 generates a report of quota limits and usage information for all users
 of the specified file system.
 .SH OPTIONS
-.TP 
+.TP
 \fI-d\fR, \fI--dirscan\fR
 Report on users who own top-level directories in the target file system.
-.TP 
+.TP
 \fI-p\fR, \fI--pwscan\fR
 Report on users from the password file.
 .TP
@@ -51,6 +51,15 @@ Suppress user lookup and report only uid's in the quota report.
 .TP
 \fI-h\fR, \fI--human-readable\fR
 Include human-readable space units in the quota report.
+.TP
+\fI-N\fR, \fI--nfs-timeout\fR \fIseconds\fR
+If a response to a single UDP NFS rquota RPC, including retries,
+is not received within this timeout, the RPC is aborted with a timeout error
+(default 2.5 seconds).
+.TP
+\fI-R\fR, \fI--nfs-retry-timeout\fR \fIseconds\fR
+If a response to a single UDP NFS rquota RPC is not received within this
+timeout, the request is retransmitted (default 0.5 seconds).
 .SH "FILES"
 @X_SYSCONFDIR@/quota.conf
 .SH "CAVEATS"

--- a/src/cmd/quota.c
+++ b/src/cmd/quota.c
@@ -60,7 +60,7 @@ static void get_login_quota(conf_t config, char *homedir, uid_t uid,
 static void get_all_quota(conf_t config, uid_t uid, List qlist,
                           int skipnolimit);
 
-#define OPTIONS "f:rvlt:Td"
+#define OPTIONS "f:rvlt:TdN:R:"
 #if HAVE_GETOPT_LONG
 #define GETOPT(ac,av,opt,lopt) getopt_long(ac,av,opt,lopt,NULL)
 static const struct option longopts[] = {
@@ -71,6 +71,8 @@ static const struct option longopts[] = {
     {"config",           required_argument,  0, 'f'},
     {"selftest",         no_argument,        0, 'T'},
     {"debug",            no_argument,        0, 'd'},
+    {"nfs-timeout",      required_argument,  0, 'N'},
+    {"nfs-retry-timeout",required_argument,  0, 'R'},
     {0, 0, 0, 0},
 };
 #else
@@ -79,6 +81,9 @@ static const struct option longopts[] = {
 
 char *prog;
 int debug = 0;
+
+extern double quota_nfs_timeout;
+extern double quota_nfs_retry_timeout;
 
 int
 main(int argc, char *argv[])
@@ -124,6 +129,12 @@ main(int argc, char *argv[])
 #endif
         case 'd':   /* --debug (undocumented) */
             debug = 1;
+            break;
+        case 'N':   /* --nfs-timeout SECS */
+            quota_nfs_timeout = strtod (optarg, NULL);
+            break;
+        case 'R':   /* --nfs-retry-timeout SECS */
+            quota_nfs_retry_timeout = strtod (optarg, NULL);
             break;
         default:
             usage();
@@ -181,7 +192,7 @@ main(int argc, char *argv[])
 static void
 usage(void)
 {
-    fprintf(stderr, "Usage: %s [-vlr] [-t sec] [-f conffile] [user]\n", prog);
+    fprintf(stderr, "Usage: %s [-vlr] [-t sec] [-N sec] [-R sec] [-f conffile] [user]\n", prog);
     exit(1);
 }
 

--- a/src/cmd/repquota.c
+++ b/src/cmd/repquota.c
@@ -58,7 +58,10 @@ static void uidscan(confent_t *conf, List qlist, List uids, int getusername);
 char *prog;
 int debug = 0;
 
-#define OPTIONS "u:b:dHrsFf:UpTDnh"
+extern double quota_nfs_timeout;
+extern double quota_nfs_retry_timeout;
+
+#define OPTIONS "u:b:dHrsFf:UpTDnhN:R:"
 #if HAVE_GETOPT_LONG
 #define GETOPT(ac,av,opt,lopt) getopt_long(ac,av,opt,lopt,NULL)
 static const struct option longopts[] = {
@@ -76,6 +79,9 @@ static const struct option longopts[] = {
     {"debug",            no_argument,        0, 'D'},
     {"nouserlookup",     no_argument,        0, 'n'},
     {"human-readable",   no_argument,        0, 'h'},
+    {"nfs-timeout",      required_argument,  0, 'N'},
+    {"nfs-retry-timeout",required_argument,  0, 'R'},
+
     {0, 0, 0, 0},
 };
 #else
@@ -160,6 +166,12 @@ main(int argc, char *argv[])
                 break;
             case 'h':   /* --human-readable */
                 hopt = 1;
+                break;
+            case 'N':   /* --nfs-timeout SECS */
+                quota_nfs_timeout = strtod (optarg, NULL);
+                break;
+            case 'R':   /* --nfs-retry-timeout SECS */
+                quota_nfs_retry_timeout = strtod (optarg, NULL);
                 break;
             default:
                 usage();
@@ -273,7 +285,11 @@ usage(void)
   "  -L,--nolimits          do not include quota limits in report\n"
   "  -n,--nouserlookup      do not try to map uid's to user names\n"
   "  -f,--config            use a config file other than %s\n"
-                , prog, _PATH_QUOTA_CONF);
+  "  -N,--nfs-timeout=SEC   set per filesystem NFS timeout (%.2fs default)\n"
+  "  -R,--nfs-retry-timeout=SEC    set NFS retry timeout (%.2fs default)\n"
+                , prog, _PATH_QUOTA_CONF,
+                quota_nfs_timeout,
+                quota_nfs_retry_timeout);
     exit(1);
 }
 

--- a/src/librpc/Makefile.am
+++ b/src/librpc/Makefile.am
@@ -27,3 +27,26 @@ rquota_xdr.c: rquota.x
 	$(RPCGEN) -o $@ -c <$<
 rquota_clnt.c: rquota.x
 	$(RPCGEN) -o $@ -l <$<
+
+#
+# Test client/server
+#
+check_PROGRAMS = \
+	rquota_svc_test \
+	rquota_clnt_test
+
+rquota_clnt_test_SOURCES = \
+	rquota_clnt_test.c
+rquota_clnt_test_LDADD = librpc.a
+
+rquota_svc_test_SOURCES = \
+	rquota_svc_main.c \
+	rquota_svc_test.c
+rquota_svc_test_LDADD = librpc.a
+
+rquota_svc_main.o: rquota.h
+
+rquota_svc_main.c: rquota.x
+	$(RPCGEN) -o $@ -s udp -DTEST <$<
+
+CLEANFILES += rquota_svc_main.c

--- a/src/librpc/rquota_clnt_test.c
+++ b/src/librpc/rquota_clnt_test.c
@@ -1,0 +1,155 @@
+/*****************************************************************************
+ *  Copyright (C) 2001-2018 The Regents of the University of California.
+ *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
+ *  Written by Jim Garlick <garlick@llnl.gov>.
+ *  UCRL-CODE-2003-005.
+ *
+ *  This file is part of Quota, a remote quota program.
+ *  For details, see <http://www.llnl.gov/linux/quota/>.
+ *
+ *  Quota is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the License, or (at your option)
+ *  any later version.
+ *
+ *  Quota is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ *  details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with Quota; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <stdarg.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/param.h>
+#include <getopt.h>
+
+#include "rquota.h"
+
+static const char *prog = "rquota_clnt_test";
+
+void die (const char *fmt, ...)
+{
+    char buf[128];
+    va_list ap;
+
+    va_start (ap, fmt);
+    vsnprintf (buf, sizeof (buf), fmt, ap);
+    va_end (ap);
+
+    fprintf (stderr, "%s: %s\n", prog, buf);
+    exit (1);
+}
+
+void usage (void)
+{
+    fprintf (stderr, "Usage: %s hostname filesystem\n", prog);
+    exit (1);
+}
+
+void print_quota (struct rquota *rq)
+{
+    printf("rq_bsize=%llu rq_curblocks=%llu rq_bsoftlimit=%llu "
+           "rq_bhardlimit=%llu rq_btimeleft=%llu rq_curfiles=%llu "
+           "rq_fsoftlimit=%llu rq_fhardlimit=%llu rq_ftimeleft=%llu\n",
+           (unsigned long long)rq->rq_bsize,
+           (unsigned long long)rq->rq_curblocks,
+           (unsigned long long)rq->rq_bsoftlimit,
+           (unsigned long long)rq->rq_bhardlimit,
+           (unsigned long long)rq->rq_btimeleft,
+           (unsigned long long)rq->rq_curfiles,
+           (unsigned long long)rq->rq_fsoftlimit,
+           (unsigned long long)rq->rq_fhardlimit,
+           (unsigned long long)rq->rq_ftimeleft);
+}
+
+void tv_double (double t, struct timeval *tv)
+{
+    tv->tv_sec = t;
+    tv->tv_usec = (t - tv->tv_sec)*1E6;
+}
+
+#define OPTIONS "N:R:"
+static const struct option longopts[] = {
+    {"nfs-timeout",      required_argument,  0, 'N'},
+    {"nfs-retry-timeout",required_argument,  0, 'R'},
+    {0, 0, 0, 0},
+};
+
+int main(int argc, char **argv)
+{
+    uid_t uid = geteuid ();
+    uid_t gid = getegid ();
+    CLIENT *cl;
+    getquota_rslt *result;
+    getquota_args args;
+    char localhost[MAXHOSTNAMELEN + 1];
+    char *host;
+    char *filesystem;
+    double retry_timeout = -1.;
+    double total_timeout = -1.;
+    int c;
+
+    while ((c = getopt_long (argc, argv, OPTIONS, longopts, NULL)) != EOF) {
+        switch (c) {
+            case 'R':   // --nfs-retry-timeout=SEC
+                retry_timeout = strtod (optarg, NULL);
+                break;
+            case 'N':   // --nfs-timeout=SEC
+                total_timeout = strtod (optarg, NULL);
+                break;
+            default:
+                usage ();
+        }
+    };
+    if (optind != argc - 2)
+        usage ();
+    host = argv[optind++];
+    filesystem = argv[optind++];
+
+    if (!(cl = clnt_create (host, RQUOTAPROG, RQUOTAVERS, "udp")))
+        die ("clnt_create");
+    if (retry_timeout >= 0.) {
+        struct timeval tv;
+        tv_double (retry_timeout, &tv);
+        if (!clnt_control (cl, CLSET_RETRY_TIMEOUT, (char *)&tv))
+            die ("clnt_control CLSET_RETRY_TIMEOUT");
+    }
+    if (total_timeout >= 0.) {
+        struct timeval tv;
+        tv_double (total_timeout, &tv);
+        if (!clnt_control (cl, CLSET_TIMEOUT, (char *)&tv))
+            die ("clnt_control CLSET_TIMEOUT");
+    }
+    if (gethostname (localhost, sizeof (localhost)) < 0)
+        die ("gethostname");
+    if (!(cl->cl_auth = authunix_create (localhost, uid, gid, 0, NULL)))
+        die ("authunix_create");
+    args.gqa_pathp = filesystem;
+    args.gqa_uid = uid;
+    if (!(result = rquotaproc_getquota_1 (&args, cl)))
+        die ("%s", clnt_sperror (cl, host));
+    if (result->gqr_status == Q_NOQUOTA)
+        die ("No quota");
+    if (result->gqr_status == Q_EPERM)
+        die ("Permission denied");
+    if (result->gqr_status != Q_OK)
+        die ("Error %d", result->gqr_status);
+    print_quota (&result->getquota_rslt_u.gqr_rquota);
+    auth_destroy (cl->cl_auth);
+    clnt_destroy (cl);
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/librpc/rquota_svc_test.c
+++ b/src/librpc/rquota_svc_test.c
@@ -1,0 +1,82 @@
+/*  Copyright (C) 2001-2018 The Regents of the University of California.
+ *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
+ *  Written by Jim Garlick <garlick@llnl.gov>.
+ *  UCRL-CODE-2003-005.
+ *
+ *  This file is part of Quota, a remote quota program.
+ *  For details, see <http://www.llnl.gov/linux/quota/>.
+ *
+ *  Quota is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the License, or (at your option)
+ *  any later version.
+ *
+ *  Quota is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ *  details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with Quota; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <unistd.h>
+#include "rquota.h"
+
+/* TODO: Server implementation for testing
+ */
+
+void rquota_bump (struct rquota *rq)
+{
+    rq->rq_bsize++;
+    rq->rq_active++;
+
+    rq->rq_bhardlimit++;
+    rq->rq_bsoftlimit++;
+    rq->rq_curblocks++;
+
+    rq->rq_fhardlimit++;
+    rq->rq_fsoftlimit++;
+    rq->rq_curfiles++;
+
+    rq->rq_btimeleft++;
+    rq->rq_ftimeleft++;
+}
+
+getquota_rslt *rquotaproc_getquota_1_svc(getquota_args *args,
+					 struct svc_req *req)
+{
+    static getquota_rslt res;
+
+    fprintf (stderr, "%s: uid=%d path=%s\n", __FUNCTION__,
+             args->gqa_uid, args->gqa_pathp);
+    if (!(strcmp (args->gqa_pathp, "drop")))
+        return NULL; // no response
+    if (!(strcmp (args->gqa_pathp, "exit")))
+        exit (0);
+    res.gqr_status = Q_OK;
+    rquota_bump (&res.getquota_rslt_u.gqr_rquota);
+    return &res;
+}
+
+getquota_rslt * rquotaproc_getactivequota_1_svc(getquota_args *args,
+						struct svc_req *req)
+{
+    static getquota_rslt res;
+
+    fprintf (stderr, "%s: uid=%d path=%s\n", __FUNCTION__,
+             args->gqa_uid, args->gqa_pathp);
+    res.gqr_status = Q_OK;
+    rquota_bump (&res.getquota_rslt_u.gqr_rquota);
+    return &res;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+


### PR DESCRIPTION
This PR changes the defualt timeouts for `rquota` when qerying NFS servers from 25s per file system, with retries every 5s; to 1s per file system, with retries every 100ms.

It's based on top of PR #13.  When that gets merged I'll rebase this one.