### PR TITLE
Fix bug in Lustre set_state and change threshold to be based on soft quota

### DIFF
--- a/src/cmd/getquota.c
+++ b/src/cmd/getquota.c
@@ -419,7 +419,7 @@ report_warning(quota_t q, char *label, char *prefix)
         case NONE:
             break;
         case UNDER:
-            if (over_thresh(q->q_bytes_used, q->q_bytes_hardlim, q->q_thresh)) {
+            if (over_thresh(q->q_bytes_used, q->q_bytes_softlim, q->q_thresh)) {
                 printf("%sBlock usage on %s has exceeded %d%% of quota.\n",
                     prefix, label, q->q_thresh);
                 msg++;

--- a/src/cmd/getquota_lustre.c
+++ b/src/cmd/getquota_lustre.c
@@ -59,7 +59,10 @@ set_state(unsigned long long used, unsigned long long soft,
     else if (hard && used > hard)
         state = EXPIRED;
     else if (soft && used > soft)
-        state = xtim > now ? STARTED : NOTSTARTED;
+        if (xtim)
+            state = xtim > now ? STARTED : EXPIRED;
+        else
+            state = UNDER;
     else
         state = UNDER;
 

--- a/src/cmd/getquota_private.h
+++ b/src/cmd/getquota_private.h
@@ -23,6 +23,14 @@
 \*****************************************************************************/
 
 typedef enum { NONE, UNDER, NOTSTARTED, STARTED, EXPIRED } qstate_t;
+/*
+ * NONE     quotas not set
+ * UNDER    used < soft
+ * NOTSTARTED  soft < used < hard && no grace period set - NFS only
+ * STARTED  soft < used < hard && now < grace_expiration
+ * EXPIRED  hard < used || (soft < used < hard && now >= grace_expiration)
+ */
+
 #define QUOTA_MAGIC 0x3434aaaf
 struct quota_struct {
     int                q_magic;


### PR DESCRIPTION
* c844c34 Report warnings based on soft quota
* 6a3152e Describe the meaning of states UNDER, NOTSTARTED, etc.
* a70e037 Correct Lustre set_state

I found that a few of the states, e.g. NOTSTARTED and NONE, were not self explanatory, which is the reason for the middle commit.  One could argue that they're good enough and on just needs to have the set_state code and the report_warning code open at the same time.  Let me know what you think.

I think the top and bottom commits are genuinely necessary, and so I created issues for them to provide a place for discussion.

I tested by hand against Lustre and NFS, and also ran make check successfully.