### PR TITLE
Use TI-RPC if available

### DIFF
--- a/config/ac_tirpc.m4
+++ b/config/ac_tirpc.m4
@@ -1,0 +1,23 @@
+AC_DEFUN([AC_LIBTIRPC],
+[
+  AC_ARG_WITH([tirpc],
+    [AS_HELP_STRING([--with-tirpc],
+      [support tirpc for querying NFS quotas @<:@default=check@:>@])],
+    [],
+    [with_tirpc=check])
+
+    LIBTIRPC=
+    LIBTIRPC_CFLAGS=
+    AS_IF([test "x$with_tirpc" != xno],
+      [AC_CHECK_LIB([tirpc], [xdrmem_create],
+        [AC_SUBST([LIBTIRPC], ["-ltirpc"])
+         AC_SUBST([LIBTIRPC_CFLAGS], [-I/usr/include/tirpc])
+         AC_DEFINE([HAVE_LIBTIRPC], [1],
+                   [Define if you have tirpc])
+        ],
+        [if test "x$with_tirpc" != xcheck; then
+           AC_MSG_FAILURE(
+             [--with-tirpc was given, but test for tirpc failed])
+         fi
+        ], )])
+])

--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,9 @@ fi
 AC_PROG_RANLIB
 AC_PATH_PROG([RPCGEN], [rpcgen], [no])
 AM_CONDITIONAL([HAVE_RPCGEN], [test "x$ac_cv_path_RPCGEN" != "xno"])
-
+if test "$RPCGEN" = no; then
+  AC_MSG_ERROR([Unable to find rpcgen, required to get quotas for NFS file systems])
+fi
 
 ##
 # Checks for header files.

--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,8 @@ if test "$RPCGEN" = no; then
   AC_MSG_ERROR([Unable to find rpcgen, required to get quotas for NFS file systems])
 fi
 
+AC_LIBTIRPC
+
 ##
 # Checks for header files.
 ##

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -3,7 +3,8 @@ AM_CFLAGS = @GCCWARN@
 AM_CPPFLAGS = \
 	-D_PATH_QUOTA_CONF=\"@X_SYSCONFDIR@/quota.conf\" \
 	-I$(top_srcdir) \
-	-I$(top_builddir)
+	-I$(top_builddir) \
+	$(LIBTIRPC_CFLAGS)
 
 bin_PROGRAMS = quota repquota
 
@@ -17,7 +18,8 @@ repquota_LDADD = $(common_ldadd)
 common_ldadd = \
 	$(top_builddir)/src/liblsd/liblsd.a \
 	$(top_builddir)/src/libutil/libutil.a \
-	$(top_builddir)/src/librpc/librpc.a
+	$(top_builddir)/src/librpc/librpc.a \
+	$(LIBTIRPC)
 
 common_sources = \
 	getquota.c \

--- a/src/librpc/Makefile.am
+++ b/src/librpc/Makefile.am
@@ -4,6 +4,7 @@ AM_CFLAGS = @GCCWARN@
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
+	-I/usr/include/tirpc \
 	-include rquota.h
 
 noinst_LIBRARIES = librpc.a


### PR DESCRIPTION
Under RHEL 7, glibc provides the header files and libraries needed to
use XDR primitives.  Under RHEL 8, this is provided by libtirpc and
libtirpc-devel.

The Fedora change:
https://fedoraproject.org/wiki/Changes/SunRPCRemoval

Add a configure check for tirpc and if found, look for headers in
/usr/include/tirpc and link against libtirpc.

This changes the default behavior to use TI-RPC if available, even under
RHEL 7.  To use the glibc implementation, use

  configure --with-tirpc=no

Also, fail in configure if rpcgen is not available since we need that as well.