### PR TITLE
Remove hardcoded path and link check programs against tirpc

### DIFF
--- a/src/librpc/Makefile.am
+++ b/src/librpc/Makefile.am
@@ -4,7 +4,7 @@ AM_CFLAGS = @GCCWARN@
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
-	-I/usr/include/tirpc \
+	$(LIBTIRPC_CFLAGS) \
 	-include rquota.h
 
 noinst_LIBRARIES = librpc.a
@@ -38,12 +38,12 @@ check_PROGRAMS = \
 
 rquota_clnt_test_SOURCES = \
 	rquota_clnt_test.c
-rquota_clnt_test_LDADD = librpc.a
+rquota_clnt_test_LDADD = librpc.a $(LIBTIRPC)
 
 rquota_svc_test_SOURCES = \
 	rquota_svc_main.c \
 	rquota_svc_test.c
-rquota_svc_test_LDADD = librpc.a
+rquota_svc_test_LDADD = librpc.a $(LIBTIRPC)
 
 rquota_svc_main.o: rquota.h
 


### PR DESCRIPTION
Fix two bugs in earlier commit:
	f17c663 Use tirpc if available

* Accidentally hard-coded path to tirpc/rpc/rpc.h, intended to use the variable defined by the autoconf check.

* Overlooked linking the check binaries against tirpc, so "make check" can work.